### PR TITLE
Fix error on linux about figlet fonts due to case insensitivity of filesystem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Scrape the entire Bitcoin chart history to JSON.
 git clone https://github.com/F1LT3R/bitcoin-scraper.git
 cd bitcoin-scraper
 npm install
+mkdir data
 node scrape.js
 ```
 

--- a/combine.js
+++ b/combine.js
@@ -8,7 +8,7 @@ const outputFile = process.argv.slice(2)[0]
 const dataDir = 'data/'
 
 console.log(chalk.green(figlet.textSync('Bitcoin Chart Scraper', {
-	font: 'pepper',
+	font: 'Pepper',
 	kerning: 'fitted'
 })))
 console.log(chalk.dim(`Combining data to=${chalk.yellow(outputFile)} \n`))

--- a/scrape.js
+++ b/scrape.js
@@ -32,7 +32,7 @@ const formatApiUrl = (market, date) => {
 }
 
 console.log(chalk.green(figlet.textSync('Bitcoin Chart Scraper', {
-	font: 'pepper',
+	font: 'Pepper',
 	kerning: 'fitted'
 })))
 console.log(chalk.dim(`Running with maxstreams=${chalk.yellow(maxstreams)} \n`))


### PR DESCRIPTION
Also added a line to the readme 
```
mkdir data
```
Which seems to be required before first run of the scraper.