### PR TITLE
UTC year + 2 digits months and days + coding styles

### DIFF
--- a/chart.html
+++ b/chart.html
@@ -1,4 +1,4 @@
-<!DOCTYPE=html>
+<!DOCTYPE html>
 <style>* {margin: 0; padding: 0;}</style>
 <canvas id="chart"></canvas>
 <div id="log"></div>

--- a/chart.js
+++ b/chart.js
@@ -3,7 +3,7 @@ const dataFile = 'data/bitcoin-history.json'
 const chart = document.getElementById('chart')
 const log = document.getElementById('log')
 const ctx = chart.getContext('2d')
-ctx.imageSmoothingEnabled= false
+ctx.imageSmoothingEnabled = false
 
 const width = 600
 const height = 400
@@ -60,12 +60,12 @@ const render = data => new Promise((resolve, reject) => {
 	const max_u = Math.log(max) / Math.log(10)
 	const range_u = max_u - min_u
 
-    ctx.strokeStyle = 'black'
+	ctx.strokeStyle = 'black'
 	ctx.moveTo(0, height)
 	ctx.lineTo(width, 0)
 	ctx.stroke()
 
-    ctx.fillStyle = 'red'
+	ctx.fillStyle = 'red'
 
 	// for (let i = 0; i < 600; i += 1) {
 	// 	const rowIndex = i * xratio
@@ -92,7 +92,7 @@ const render = data => new Promise((resolve, reject) => {
 		}
 
 		const x = i * ratioX
-	    const y = height - (Math.log(usd) / Math.log(10) - min_u) / range_u * height
+		const y = height - (Math.log(usd) / Math.log(10) - min_u) / range_u * height
 		ctx.fillRect(x, y, 1, 1)
 	}
 
@@ -132,11 +132,11 @@ const loadData = () => new Promise((resolve, reject) => {
 })
 
 loadData(dataFile)
-.then(render)
-.then(msg => {
-	console.log(msg)
-})
-.catch(err => {
-	console.error(err)
-	alert('Error: see console')
-})
+	.then(render)
+	.then(msg => {
+		console.log(msg)
+	})
+	.catch(err => {
+		console.error(err)
+		alert('Error: see console')
+	})

--- a/combine.js
+++ b/combine.js
@@ -15,7 +15,8 @@ console.log(chalk.dim(`Combining data to=${chalk.yellow(outputFile)} \n`))
 
 const files = []
 
-function compare (a, b) {
+function compare(a, b)
+{
 	if (a.time < b.time) {
 		return -1
 	}
@@ -75,9 +76,10 @@ fs.readdir(dataDir, (err, list) => {
 	fs.writeFile(outputFile, outputData, 'utf8', err => {
 		process.stdout.write('\n')
 
-		if(err) {
+		if (err) {
 			return console.error(chalk.red(err))
-		} else {
+		}
+		else {
 			console.log(`Saved to: ${chalk.blue(outputFile)}`)
 		}
 	})

--- a/scrape.js
+++ b/scrape.js
@@ -83,7 +83,7 @@ const go = () => new Promise((resolve, reject) => {
 			continue
 		}
 
-		const prettyDate = date.getFullYear() + '-' + zeroFill(date.getUTCMonth()+1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
+		const prettyDate = date.getUTCFullYear() + '-' + zeroFill(date.getUTCMonth()+1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
 		const dataPath = formatApiUrl(market, prettyDate)
 		const fileName = `${market}-${prettyDate}.json`
 		const filePath = path.join(dataDir, fileName)

--- a/scrape.js
+++ b/scrape.js
@@ -47,6 +47,14 @@ Date.prototype.addDays = function(days) {
   return dat
 }
 
+const zeroFill = (number, width) => {
+  width -= number.toString().length;
+  if (width > 0) {
+    return new Array(width + (/\./.test(number) ? 2 : 1)).join('0') + number;
+  }
+  return number + ""; // always return a string
+}
+
 const getDates = (startDate, stopDate) => {
   const dateArray = new Array()
   let currentDate = startDate
@@ -75,7 +83,7 @@ const go = () => new Promise((resolve, reject) => {
 			continue
 		}
 
-		const prettyDate = date.getFullYear() + '-' + (date.getUTCMonth()+1) + '-' + date.getUTCDate()
+		const prettyDate = date.getFullYear() + '-' + zeroFill(date.getUTCMonth()+1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
 		const dataPath = formatApiUrl(market, prettyDate)
 		const fileName = `${market}-${prettyDate}.json`
 		const filePath = path.join(dataDir, fileName)

--- a/scrape.js
+++ b/scrape.js
@@ -103,10 +103,10 @@ const go = () => new Promise((resolve, reject) => {
 				if (response !== undefined) {
 					cursoryUsd = response[0][7]
 				}
-					console.log(`Recevied: ${chalk.green(prettyDate)} - ${chalk.red('$' + cursoryUsd)}`)
+				console.log(`Recevied: ${chalk.green(prettyDate)} - ${chalk.red('$' + cursoryUsd)}`)
 
 				if (response === undefined) {
-					console.log(chalk.red(`Received "Undefined" data for ${chalk.white(prettyDate)}. Too many streams? (Data for ome dates are not avilable, eg: '2011-10-1')`))
+					console.log(chalk.red(`Received "Undefined" data for ${chalk.white(prettyDate)}. Too many streams? (Data for old dates are not available, eg: '2011-10-1')`))
 					response = []
 				}
 

--- a/scrape.js
+++ b/scrape.js
@@ -10,17 +10,17 @@ const dataDir = 'data'
 const market = 'bitstampUSD'
 
 const dates = {
-  from: {
-  	year: 2011,
-  	month: 9,
-  	day: 14
-  },
+	from: {
+		year: 2011,
+		month: 9,
+		day: 14
+	},
 
-  to: {
-  	year: 2017,
-  	month: 08,
-  	day: 9
-  },
+	to: {
+		year: 2017,
+		month: 08,
+		day: 9
+	},
 }
 
 const baseApiUrl = 'http://bitcoincharts.com/charts/chart.json?'
@@ -38,31 +38,31 @@ console.log(chalk.green(figlet.textSync('Bitcoin Chart Scraper', {
 console.log(chalk.dim(`Running with maxstreams=${chalk.yellow(maxstreams)} \n`))
 
 const url = (baseurl, date) => {
-  return baseurl + date
+	return baseurl + date
 }
 
-Date.prototype.addDays = function(days) {
-  const dat = new Date(this.valueOf())
-  dat.setDate(dat.getDate() + days)
-  return dat
+Date.prototype.addDays = function (days) {
+	const dat = new Date(this.valueOf())
+	dat.setDate(dat.getDate() + days)
+	return dat
 }
 
 const zeroFill = (number, width) => {
-  width -= number.toString().length;
-  if (width > 0) {
-    return new Array(width + (/\./.test(number) ? 2 : 1)).join('0') + number;
-  }
-  return number + ""; // always return a string
+	width -= number.toString().length;
+	if (width > 0) {
+		return new Array(width + (/\./.test(number) ? 2 : 1)).join('0') + number;
+	}
+	return number + ""; // always return a string
 }
 
 const getDates = (startDate, stopDate) => {
-  const dateArray = new Array()
-  let currentDate = startDate
-  while (currentDate <= stopDate) {
-    dateArray.push(currentDate)
-    currentDate = currentDate.addDays(1)
-  }
-  return dateArray
+	const dateArray = new Array()
+	let currentDate = startDate
+	while (currentDate <= stopDate) {
+		dateArray.push(currentDate)
+		currentDate = currentDate.addDays(1)
+	}
+	return dateArray
 }
 
 const start = new Date(dates.from.year, dates.from.month - 1, dates.from.day)
@@ -83,7 +83,7 @@ const go = () => new Promise((resolve, reject) => {
 			continue
 		}
 
-		const prettyDate = date.getUTCFullYear() + '-' + zeroFill(date.getUTCMonth()+1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
+		const prettyDate = date.getUTCFullYear() + '-' + zeroFill(date.getUTCMonth() + 1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
 		const dataPath = formatApiUrl(market, prettyDate)
 		const fileName = `${market}-${prettyDate}.json`
 		const filePath = path.join(dataDir, fileName)
@@ -110,13 +110,13 @@ const go = () => new Promise((resolve, reject) => {
 					response = []
 				}
 
-
 				const output = JSON.stringify(response)
 
 				fs.writeFile(filePath, output, 'utf8', err => {
-					if(err) {
+					if (err) {
 						return reject(err)
-					} else {
+					}
+					else {
 						console.log(`Saved to: ${chalk.blue(filePath)}`)
 						resolve('Ok')
 					}

--- a/scrape.js
+++ b/scrape.js
@@ -1,13 +1,13 @@
-const getJSON = require('get-json')
-const fs = require('fs')
-const path = require('path')
-const chalk = require('chalk')
-const figlet = require('figlet')
+const getJSON = require('get-json');
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const figlet = require('figlet');
 
-const maxstreams = 8
-const dataDir = 'data'
+const maxstreams = 8;
+const dataDir = 'data';
 
-const market = 'bitstampUSD'
+const market = 'bitstampUSD';
 
 const dates = {
 	from: {
@@ -18,34 +18,29 @@ const dates = {
 
 	to: {
 		year: 2017,
-		month: 08,
+		month: 8,
 		day: 9
 	},
-}
+};
 
-const baseApiUrl = 'http://bitcoincharts.com/charts/chart.json?'
+const baseApiUrl = 'http://bitcoincharts.com/charts/chart.json?';
 
 // Full parms: m=bitstampUSD&SubmitButton=Draw&r=60&i=1-min&c=1&s=2011-09-14&e=2011-09-14&Prev=&Next=&t=S&b=&a1=&m1=10&a2=&m2=25&x=0&i1=&i2=&i3=&i4=&v=1&cv=0&ps=0&l=0&p=0&
 const formatApiUrl = (market, date) => {
-	const apiUrl = `${baseApiUrl}m=${market}&SubmitButton=Draw&r=60&i=1-min&c=1&s=${date}&e=${date}&Prev=&Next=&t=S&b=&a1=&m1=10&a2=&m2=25&x=0&i1=&i2=&i3=&i4=&v=1&cv=0&ps=0&l=0&p=0&`
-	return apiUrl
-}
+	return `${baseApiUrl}m=${market}&SubmitButton=Draw&r=60&i=1-min&c=1&s=${date}&e=${date}&Prev=&Next=&t=S&b=&a1=&m1=10&a2=&m2=25&x=0&i1=&i2=&i3=&i4=&v=1&cv=0&ps=0&l=0&p=0&`;
+};
 
 console.log(chalk.green(figlet.textSync('Bitcoin Chart Scraper', {
 	font: 'Pepper',
 	kerning: 'fitted'
-})))
-console.log(chalk.dim(`Running with maxstreams=${chalk.yellow(maxstreams)} \n`))
-
-const url = (baseurl, date) => {
-	return baseurl + date
-}
+})));
+console.log(chalk.dim(`Running with maxstreams=${chalk.yellow(maxstreams)} \n`));
 
 Date.prototype.addDays = function (days) {
-	const dat = new Date(this.valueOf())
-	dat.setDate(dat.getDate() + days)
-	return dat
-}
+	const dat = new Date(this.valueOf());
+	dat.setDate(dat.getDate() + days);
+	return dat;
+};
 
 const zeroFill = (number, width) => {
 	width -= number.toString().length;
@@ -53,74 +48,74 @@ const zeroFill = (number, width) => {
 		return new Array(width + (/\./.test(number) ? 2 : 1)).join('0') + number;
 	}
 	return number + ""; // always return a string
-}
+};
 
 const getDates = (startDate, stopDate) => {
-	const dateArray = new Array()
-	let currentDate = startDate
+	const dateArray = [];
+	let currentDate = startDate;
 	while (currentDate <= stopDate) {
-		dateArray.push(currentDate)
+		dateArray.push(currentDate);
 		currentDate = currentDate.addDays(1)
 	}
 	return dateArray
-}
+};
 
-const start = new Date(dates.from.year, dates.from.month - 1, dates.from.day)
-const end = new Date(dates.to.year, dates.to.month - 1, dates.to.day)
-const dateStack = getDates(start, end)
+const start = new Date(dates.from.year, dates.from.month - 1, dates.from.day);
+const end = new Date(dates.to.year, dates.to.month - 1, dates.to.day);
+const dateStack = getDates(start, end);
 
 const go = () => new Promise((resolve, reject) => {
 	if (dateStack.length === 0) {
-		return resolve('Done!')
+		return resolve('Done!');
 	}
 
-	const pipeline = []
+	const pipeline = [];
 
 	for (let i = 0; i < maxstreams; i += 1) {
-		const date = dateStack.shift()
+		const date = dateStack.shift();
 
 		if (!date) {
-			continue
+			continue;
 		}
 
-		const prettyDate = date.getUTCFullYear() + '-' + zeroFill(date.getUTCMonth() + 1, 2) + '-' + zeroFill(date.getUTCDate(), 2)
-		const dataPath = formatApiUrl(market, prettyDate)
-		const fileName = `${market}-${prettyDate}.json`
-		const filePath = path.join(dataDir, fileName)
+		const prettyDate = date.getUTCFullYear() + '-' + zeroFill(date.getUTCMonth() + 1, 2) + '-' + zeroFill(date.getUTCDate(), 2);
+		const dataPath = formatApiUrl(market, prettyDate);
+		const fileName = `${market}-${prettyDate}.json`;
+		const filePath = path.join(dataDir, fileName);
 
 		// Don't re-download if thie file already exists
 		if (fs.existsSync(filePath)) {
-			console.log(`Passover: ${chalk.magenta(filePath)} (already exists)`)
-			continue
+			console.log(`Passover: ${chalk.magenta(filePath)} (already exists)`);
+			continue;
 		}
 
 		pipeline.push(new Promise((resolve, reject) => {
-			console.log(`Fetching: ${chalk.yellow(prettyDate)} - ${chalk.yellow.dim(dataPath)}`)
+			console.log(`Fetching: ${chalk.yellow(prettyDate)} - ${chalk.yellow.dim(dataPath)}`);
 
 			getJSON(dataPath, (error, response) => {
-				let cursoryUsd = null
+				let cursoryUsd = null;
 
 				if (response !== undefined) {
-					cursoryUsd = response[0][7]
+					cursoryUsd = response[0][7];
 				}
-				console.log(`Recevied: ${chalk.green(prettyDate)} - ${chalk.red('$' + cursoryUsd)}`)
+				console.log(`Recevied: ${chalk.green(prettyDate)} - ${chalk.red('$' + cursoryUsd)}`);
 
 				if (response === undefined) {
-					console.log(chalk.red(`Received "Undefined" data for ${chalk.white(prettyDate)}. Too many streams? (Data for old dates are not available, eg: '2011-10-1')`))
-					response = []
+					console.log(chalk.red(`Received "Undefined" data for ${chalk.white(prettyDate)}. Too many streams? (Data for old dates are not available, eg: '2011-10-1')`));
+					response = [];
 				}
 
-				const output = JSON.stringify(response)
+				const output = JSON.stringify(response);
 
 				fs.writeFile(filePath, output, 'utf8', err => {
 					if (err) {
-						return reject(err)
+						return reject(err);
 					}
 					else {
-						console.log(`Saved to: ${chalk.blue(filePath)}`)
-						resolve('Ok')
+						console.log(`Saved to: ${chalk.blue(filePath)}`);
+						resolve('Ok');
 					}
-				})
+				});
 			})
 		}))
 	}
@@ -129,12 +124,12 @@ const go = () => new Promise((resolve, reject) => {
 		resolve(go())
 	}).catch(err => {
 		reject(err)
-	})
-})
+	});
+});
 
 go().then(() => {
 	console.log(chalk.magenta('DONE!'))
 }).catch(err => {
 	console.error(err)
-})
+});
 


### PR DESCRIPTION
1 bug fix (9df44cc) - Use getUTCFullYear() to avoid inconsistent year:
1 improvement (5674d07) - Months and days are now always 2 digits long

The rest is cosmetics.

